### PR TITLE
Fix argument truncation for strings with unicode characters

### DIFF
--- a/lib/RPCConnection.js
+++ b/lib/RPCConnection.js
@@ -18,10 +18,11 @@ RPCConnection.prototype.call = function (name, args, callback) {
 
     var dataSize = (2 + name.length);
     for (var i = 0; i < args.length; i++) {
-        if (args[i].length > 65535) {
+        var argLength = Buffer.byteLength(args[i], 'utf8');
+        if (argLength > 65535) {
             throw new Error('Each RPC function argument has a 16 bit size limit (65535 bytes) in uWSGI.');
         }
-        dataSize += 2 + args[i].length;
+        dataSize += 2 + argLength;
     }
 
     // Create uwsgi packet header (http://uwsgi-docs.readthedocs.org/en/latest/Protocol.html)
@@ -39,9 +40,10 @@ RPCConnection.prototype.call = function (name, args, callback) {
     // Write arguments to buffer
     var pos = name.length + 2;
     for (i = 0; i < args.length; i++) {
-        body.writeUInt16LE(args[i].length, pos, 1);
+        var argLength = Buffer.byteLength(args[i], 'utf8');
+        body.writeUInt16LE(argLength, pos, 1);
         body.write(args[i], pos + 2, 'utf8');
-        pos = pos + args[i].length + 2;
+        pos = pos + argLength + 2;
     }
 
     // Send data


### PR DESCRIPTION
If any of the arguments contain a unicode character that requires more than 1 byte to be represented the dataSize will be incorrect and the data sent truncated. ".length" will only return the number of characters, but Buffer takes bytes.
