### PR TITLE
Avoid stringifying undefined and null into strings like 'null'

### DIFF
--- a/lib/RPCConnection.js
+++ b/lib/RPCConnection.js
@@ -13,6 +13,11 @@ RPCConnection.prototype.call = function (name, args, callback) {
     }
 
     args = args.map(function (value) {
+        // Avoid stringifying undefined and null into strings like 'null'
+        if (value === undefined || value === null) {
+            return '';
+        }
+
         return '' + value;
     });
 


### PR DESCRIPTION
It doesn't seem to be easily possible to actually pass an undefined value, so empty string is the next best thing I suppose.

Without this PR null values are converted to 'null' (as a string) and undefined values to 'undefined'.